### PR TITLE
doc language - cs3a.md - followup

### DIFF
--- a/cs/3a.md
+++ b/cs/3a.md
@@ -1,7 +1,7 @@
 Cipher Set 3a
 ============
 
-Cipher Set 3a is based on Daniel J. Bernstein's [NaCl: Networking and Cryptography library](http://nacl.cr.yp.to/index.html).  The cipher set leverages the public-key and secret-key portions of NaCl.  Implementations will need to support crypto_box, crypto_secretbox, and crypto_onetimeauth related functions.
+Cipher Set 3a is based on Daniel J. Bernstein's [NaCl: Networking and Cryptography library](http://nacl.cr.yp.to/index.html).  The cipher set leverages the public-key and secret-key portions of NaCl.  Implementations will need to support the crypto_box, crypto_secretbox, and crypto_onetimeauth related functions.
 
 
 ## Switch Key Pair and Fingerprint
@@ -22,7 +22,7 @@ In order to create a new line, a switch must generate a new, temporary key pair 
 The BODY of the open packet is binary and defined as the following byte sections in sequential order:
 
 * `AUTH` - 32 bytes, the calculated onetimeauth(line key, inner ciphertext)
-* `LINE KEY` - 32 bytes, the sender's temporary line public key
+* `LINE KEY` - 32 bytes, the sender's line level public key
 * `INNER CIPHERTEXT` - the secretbox() encrypted inner packet
 
 ## Line
@@ -40,7 +40,7 @@ The enclosing line packet binary is defined as the following byte sections in se
 
 ## Example Code For Discussion (open handshake)
 
-The following example illustrates the usage of cs3a for the sending and receiving sides of an `open` request.
+The following example illustrates the usage of cs3a for the sending and receiving sides of an `open` request.  Warning: pseudo code interspersed with real code.
 
 Sender (initiating an open request):
 ```js
@@ -57,37 +57,46 @@ var senderKeys = sodium.crypto_box_keypair();
 var senderLineKeys = sodium.crypto_box_keypair();
 
 // Generate a 24 byte nonce of 0
+// Both sender and receiver must use the same initial nonce.
 var nonce = new Buffer(24);
 for (var i = 0; i < 24; ++i) {
   nonce[i] = 0;
 }
 
-// Before any specific message handling, a message independent pre-computaion
-// is performed, generating the agreedKey.  This key is used as a part of the
-// encryption process for all packets sent over the line.
+// Generate the shared secret (agreedKey)
+// Before any specific message handling, this "message independent pre-computaion"
+// is performed, generating the agreedKey.  This shared secret is later used as a
+// part of the encryption process for all packets sent over the line.
 var agreedKey = sodium.crypto_box_beforenm(receiverKeys.publicKey, senderLineKeys.secretKey);
 
-// Sample inner packet (json fields can be found in spec for open)
+// Generate the macKey
+// The macKey uses the switch level private key.
+var macKey = sodium.crypto_box_beforenm(receiverKeys.publicKey, senderKeys.secretKey);
+
+// Sample inner packet
+// (The json schema can be found in the spec for open)
 var plainText = JSON.stringify("This is a test chunk of data for the inner packet. it would have JSON and a payload of the sender publicKey");
 
 // Encrypt the inner packet
-// Note that this step uses NaCl's crypto_secretbox from the components for secret-key cryptography
+// Note that this step uses NaCl's crypto_secretbox from the components for
+// secret-key cryptography.
 var innerPacketData = sodium.crypto_secretbox(new Buffer(plainText), nonce, agreedKey);
 
-// Take the encrypted inner packet and build the data section of the outer packet
+// Take the encrypted inner packet and the line level public key, and build the
+// data section of the outer packet.
 var openPacketData = Buffer.concat([senderLineKeys.publicKey, innerPacketData]);
 
-// Generate the macKey using the switch level private key
-var macKey = sodium.crypto_box_beforenm(receiverKeys.publicKey, senderKeys.secretKey);
-
-// Generate the HMAC
+// Generate the open HMAC
 // Note that this uses the NaCl's crypto_onetimeauth from the components for
-// secret-key cryptography
+// secret-key cryptography.
 var openHMAC = sodium.crypto_onetimeauth(openPacketData, macKey);
 
-// Sender can now send HMAC, public line key and the encrypted open packet data
+// Generate the outer packet BODY
+// <open-HMAC><sender-line-public-key><encrypted-inner-packet-data>
+var openPacketBody = Buffer.concat([openHMAC, openPacketData]);
 
 ```
+
 
 Receiver (accepting an open request):
 ```js
@@ -102,38 +111,52 @@ var receiverKeys = sodium.crypto_box_keypair();
 // Upon receiving an open request, a line specific key pair is generated.
 var receiverLineKeys = sodium.crypto_box_keypair();
 
-// Generate a 24 byte nonce of 0 (same as sender for open)
+// Unpack and authenticate the outer packet
+//
+// At this point, the open packet has been received.  Remember the following
+// format:
+// <open-HMAC><sender-line-public-key><encrypted-inner-packet-data>
+//
+var openHMAC = ...                  // the leading 32 bytes 
+var senderLineKeys.publicKey = ...  // the next 32 bytes
+var innerPacketData = ...           // the remaining bytes are the encrypted inner packet data
+var openPacketData = ...            // Buffer.concat([senderLineKeys.publicKey, innerPacketData]);
+
+// Generate the macKey
+// This macKey will match the macKey generated by the sender, due to the corresponding
+// public/private keys.  Here is the sender version for comparison:
+//  macKey = sodium.crypto_box_beforenm(receiverKeys.publicKey, senderKeys.secretKey);
+//
+var macKey = sodium.crypto_box_beforenm(senderKeys.publicKey, receiverKeys.secretKey);
+
+// Authenticate the open packet
+// With all the pieces available, a onetimeauth verification can be completed.  If
+// successful, this step completes the authentication of the open request.
+var authed = sodium.crypto_onetimeauth_verify(openHMAC, openPacketData, macKey) === 0 ;
+console.log("Open hmac verify:", authed);
+
+
+// Auth successful?  The decryption can proceed.
+
+
+// Generate a 24 byte nonce of 0
+// (same as sender for open)
 var nonce = new Buffer(24);
 for (var i = 0; i < 24; ++i) {
   nonce[i] = 0;
 }
 
-// Get the agreedKey out of the packet
-// Note that it will match the agreedKey generated by the sender, due to the
-// corresponding public/private keys.  Here is the sender version for
-// comparison:
+// Generate the shared secret (agreedKey)
+// This agreedKey will match the agreedKey generated by the sender, due to the
+// corresponding public/private keys.  Here is the sender version for comparison:
 //  agreedKey = sodium.crypto_box_beforenm(receiverKeys.publicKey, senderLineKeys.secretKey);
 //
 var agreedKey = sodium.crypto_box_beforenm(senderLineKeys.publicKey, receiverKeys.secretKey);
 
 // Decrypt the inner packet
-// This will match the sample plaintext from the sender example
-var decryptedPacketData = sodium.crypto_secretbox_open(innerPacketData, nonce, recvAgreedKey);
+// Using the agreedKey, the inner packet can now be decrypted. This should match
+// the sample plaintext from the sender example.
+var decryptedPacketData = sodium.crypto_secretbox_open(innerPacketData, nonce, agreedKey);
 
-// Generate the macKey
-// Note that it will match the macKey generated by the sender, due to the
-// corresponding public/private keys.  Here is the sender version for
-// comparison:
-//  macKey = sodium.crypto_box_beforenm(receiverKeys.publicKey, senderKeys.secretKey);
-//
-var macKey = sodium.crypto_box_beforenm(senderKeys.publicKey, receiverKeys.secretKey);
-
-// Validate the HMAC of the outer packet
-// Now the receiver also generates the same openHMAC with that macKey.  Then, having
-// generated the openHMAC and macKey as the sender, the open packet can be validated
-// by verifying the HMAC with crypto_onetimeauth_verify.
-var openHMAC = sodium.crypto_onetimeauth(openPacketData, macKey);
-var authed = sodium.crypto_onetimeauth_verify(openHMAC, openPacketData, macKey) === 0 ;
-console.log("Open hmac verify:", authed);
 ```
 


### PR DESCRIPTION
I put some fresh eyes on my recent cs3a doc changes and found some mistakes.  Here are some corrections and enhancements for consideration.  This should also clarify the distinction between authenticating and decrypting the open packet.

thanks!
cody
