### PR TITLE
doc update - cs3a - hmac byte length

### DIFF
--- a/cs/3a.md
+++ b/cs/3a.md
@@ -21,7 +21,7 @@ In order to create a new line, a switch must generate a new, temporary key pair 
 
 The BODY of the open packet is binary and defined as the following byte sections in sequential order:
 
-* `AUTH` - 32 bytes, the calculated onetimeauth(line key, inner ciphertext)
+* `AUTH` - 16 bytes, the calculated onetimeauth(line key, inner ciphertext)
 * `LINE KEY` - 32 bytes, the sender's line level public key
 * `INNER CIPHERTEXT` - the secretbox() encrypted inner packet
 
@@ -69,10 +69,6 @@ for (var i = 0; i < 24; ++i) {
 // part of the encryption process for all packets sent over the line.
 var agreedKey = sodium.crypto_box_beforenm(receiverKeys.publicKey, senderLineKeys.secretKey);
 
-// Generate the macKey
-// The macKey uses the switch level private key.
-var macKey = sodium.crypto_box_beforenm(receiverKeys.publicKey, senderKeys.secretKey);
-
 // Sample inner packet
 // (The json schema can be found in the spec for open)
 var plainText = JSON.stringify("This is a test chunk of data for the inner packet. it would have JSON and a payload of the sender publicKey");
@@ -85,6 +81,10 @@ var innerPacketData = sodium.crypto_secretbox(new Buffer(plainText), nonce, agre
 // Take the encrypted inner packet and the line level public key, and build the
 // data section of the outer packet.
 var openPacketData = Buffer.concat([senderLineKeys.publicKey, innerPacketData]);
+
+// Generate the macKey
+// The macKey uses the switch level private key.
+var macKey = sodium.crypto_box_beforenm(receiverKeys.publicKey, senderKeys.secretKey);
 
 // Generate the open HMAC
 // Note that this uses the NaCl's crypto_onetimeauth from the components for
@@ -117,7 +117,7 @@ var receiverLineKeys = sodium.crypto_box_keypair();
 // format:
 // <open-HMAC><sender-line-public-key><encrypted-inner-packet-data>
 //
-var openHMAC = ...                  // the leading 32 bytes 
+var openHMAC = ...                  // the leading 16 bytes 
 var senderLineKeys.publicKey = ...  // the next 32 bytes
 var innerPacketData = ...           // the remaining bytes are the encrypted inner packet data
 var openPacketData = ...            // Buffer.concat([senderLineKeys.publicKey, innerPacketData]);


### PR DESCRIPTION
The cs3a doc previously noted that the onetimeauth hmac was 32 bytes in length.  Per the NaCl documentation, the hmac is 16 bytes.  This diff corrects that value.

It also makes a minor change to the sender code example for clarity.

Thanks!
cody
