### PR TITLE
doc update - cs3a - change hmac references to mac

### DIFF
--- a/cs/3a.md
+++ b/cs/3a.md
@@ -86,14 +86,14 @@ var openPacketData = Buffer.concat([senderLineKeys.publicKey, innerPacketData]);
 // The macKey uses the switch level private key.
 var macKey = sodium.crypto_box_beforenm(receiverKeys.publicKey, senderKeys.secretKey);
 
-// Generate the open HMAC
+// Generate the open MAC
 // Note that this uses the NaCl's crypto_onetimeauth from the components for
 // secret-key cryptography.
-var openHMAC = sodium.crypto_onetimeauth(openPacketData, macKey);
+var openMAC = sodium.crypto_onetimeauth(openPacketData, macKey);
 
 // Generate the outer packet BODY
-// <open-HMAC><sender-line-public-key><encrypted-inner-packet-data>
-var openPacketBody = Buffer.concat([openHMAC, openPacketData]);
+// <open-MAC><sender-line-public-key><encrypted-inner-packet-data>
+var openPacketBody = Buffer.concat([openMAC, openPacketData]);
 
 ```
 
@@ -115,9 +115,9 @@ var receiverLineKeys = sodium.crypto_box_keypair();
 //
 // At this point, the open packet has been received.  Remember the following
 // format:
-// <open-HMAC><sender-line-public-key><encrypted-inner-packet-data>
+// <open-MAC><sender-line-public-key><encrypted-inner-packet-data>
 //
-var openHMAC = ...                  // the leading 16 bytes 
+var openMAC = ...                  // the leading 16 bytes 
 var senderLineKeys.publicKey = ...  // the next 32 bytes
 var innerPacketData = ...           // the remaining bytes are the encrypted inner packet data
 var openPacketData = ...            // Buffer.concat([senderLineKeys.publicKey, innerPacketData]);
@@ -132,8 +132,8 @@ var macKey = sodium.crypto_box_beforenm(senderKeys.publicKey, receiverKeys.secre
 // Authenticate the open packet
 // With all the pieces available, a onetimeauth verification can be completed.  If
 // successful, this step completes the authentication of the open request.
-var authed = sodium.crypto_onetimeauth_verify(openHMAC, openPacketData, macKey) === 0 ;
-console.log("Open hmac verify:", authed);
+var authed = sodium.crypto_onetimeauth_verify(openMAC, openPacketData, macKey) === 0 ;
+console.log("Open mac verify:", authed);
 
 
 // Auth successful?  The decryption can proceed.


### PR DESCRIPTION
Here's a minor terminology correction.  In NaCL, the crypto_onetimeauth is a MAC, but not of the flavor HMAC.  @dvanduzer did the leg work to verify this in djb's documentation.

regards,
cody
