### PR TITLE
Fix grammar on home page: it's → its

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@ A secure wire protocol powering a decentralized overlay network for apps and dev
 <div class="stripe" id="steps">
 <div class="span-8">
 <h3>What</h3>
-	<p>It works by having every application generate it's own unique public-key based address (hashname) that can send and receive small encrypted packets of <a href="http://www.json.org/">JSON</a> (with optional binary payloads), and provides an automatic routing system based on <a href="http://en.wikipedia.org/wiki/Kademlia">Kademlia</a>, a proven and popular <a href="http://en.wikipedia.org/wiki/Distributed_hash_table">Distributed Hash Table</a>.  
+	<p>It works by having every application generate its own unique public-key based address (hashname) that can send and receive small encrypted packets of <a href="http://www.json.org/">JSON</a> (with optional binary payloads), and provides an automatic routing system based on <a href="http://en.wikipedia.org/wiki/Kademlia">Kademlia</a>, a proven and popular <a href="http://en.wikipedia.org/wiki/Distributed_hash_table">Distributed Hash Table</a>.  
 </div>
 <div class="span-8">
 <h3>Demo</h3>


### PR DESCRIPTION
As pointed out [on Hacker News](https://news.ycombinator.com/item?id=8023930).
