### PR TITLE
Box channels for v3

### DIFF
--- a/v3/channels/box.md
+++ b/v3/channels/box.md
@@ -14,9 +14,9 @@ A `box` always has a consistent unique ID that is the [SipHash](http://en.wikipe
 
 Every message has a unique ID within a box that is the SipHash of the message bytes with the box ID as the key.
 
-## Advertising Capacity/Status
+## Advertising Status - `boxes`
 
-Box status is advertised after an exchange is first [synchronized](../e3x/handshake.md) as an unreliable channel of type `boxes`.  Any endpoint that has cached messages should automatically initiate this channel to indicate status to the recipient.
+Box status is advertised as an unreliable channel of type `boxes` always opened to the recipient.  Any endpoint that has cached messages should automatically initiate this channel to indicate status to the recipient, typically when an exchange is first [synchronized](../e3x/handshake.md) but also whenever an empty box has a message added.
 
 ```
 {
@@ -29,15 +29,15 @@ The BODY is the list of binary 64-bit box IDs with messages waiting, only 120 ID
 
 No additional data is returned (such as size of each box, timestamps, or sorting) in order to minimize the metadata the sender is required to maintain.
 
-## Sending - `box`
+## Sending - `outbox`
 
-The `box` channel is always reliable and initiated by the sender to a caching server or directly to the recipient.
+The `outbox` channel is always reliable and initiated by the sender to a caching server or directly to the recipient.
 
 ```json
 {
   "c":1,
   "seq":1,
-  "type":"box",
+  "type":"outbox",
   "to":"uvabrvfqacyvgcu8kbrrmk9apjbvgvn2wjechqr3vf9c1zm3hv7g"
 }
 ```
@@ -71,4 +71,4 @@ Every packet sent back will contain message bytes as the BODY, if the message is
 
 Once all messages are sent, or when there are no messages or the box is unknown, the server must send a packet that contains a `"cap":1234` of an unsigned integer to indicate the number of bytes of message data it will cache for the given box ID.
 
-Identically to the `box` channel, any packet sent back with an `"id":"16-hex"` only is a request to clear/remove any matching message in the box, and a `"clear":true` immediately empties all of the messages in the box regardless of status.  The server will always respond with an updated `cap` value.
+Identically to the `outbox` channel, any packet sent back with an `"id":"16-hex"` only is a request to clear/remove any matching message in the box, and a `"clear":true` immediately empties all of the messages in the box regardless of status.  The server will always respond with an updated `cap` value.

--- a/v3/channels/box.md
+++ b/v3/channels/box.md
@@ -12,17 +12,17 @@ A `box` always has a consistent unique ID that is the [SipHash](http://en.wikipe
 
 ## Advertising Capacity/Status
 
-Box status is advertised during any [handshake](../e3x/handshake.md) as a message using a "box" type:
+Box status is advertised when an exchange is [synchronized](../e3x/handshake.md) as a channel of type "boxes":
 
 ```
 {
-  "type": "box",
+  "type": "boxes",
   "quota": [used, capacity]
 }
 BODY: id1, id2, id3
 ```
 
-The BODY is the list of binary 64-bit box IDs with messages waiting, only the first 120 IDs are included, any additional are truncated and must be retrieved dynamiclly by the recipient.
+The BODY is the list of binary 64-bit box IDs with messages waiting, only the first 120 IDs are included, any additional are sent in the next message on the channel.
 
 The quota is an array of two unsigned integers where the first number is how many total waiting messages there are for the recipient, and the second is how many messages the sender is willing to cache for the recipient.
 
@@ -38,7 +38,7 @@ When a box channel is opened by a sender to a recipient it uses the format:
 {
   "c":1,
   "seq":1,
-  "type":"box",
+  "type":"oubox",
   "to":"uvabrvfqacyvgcu8kbrrmk9apjbvgvn2wjechqr3vf9c1zm3hv7g"
 }
 ```
@@ -53,7 +53,7 @@ A recipient opens a box channel to receive any waiting messages with the format:
 {
   "c":1,
   "seq":1,
-  "type":"box",
+  "type":"inbox",
   "box":"851042800434dd49"
 }
 ```

--- a/v3/channels/box.md
+++ b/v3/channels/box.md
@@ -1,34 +1,69 @@
-# Box - Sending/Receiving Messages (direct or DHT)
+# Box - Offline Signalling (Store-and-Forward)
 
 > This is a **rough draft** and a work in progress
 
-The box channel is used to send and receive [messages](../e3x/messages.md) directly or from any third party hashname that is acting as a cache.  The caching hosts can be selected automatically based on DHT proximity or chosen specifically based on the application's design (fixed servers, known/elected peers, etc).
+The box channel is used to asynchronously send and receive encrypted [messages](../e3x/messages.md) directly or via any shared hashname that is acting as a cache/router.  A caching entity can be selected automatically based on capacity/availability or chosen specifically based on app configuration.
 
-A box channel is always opened for a specific hashname.  The given "box" hashname combined with the sender is the unique identity of the box. The channel is client-server oriented (not bi-directional, one could be open in both directions) where the initial request is sent by the client and the recipient is the server.  Upon opening, any waiting messages for the client are sent.
+The use of remote entities to provide caching should be considered carefully and minimized, they must be trusted to not collect metadata about the status and volume of signalling between any hashnames using them, as well as to not archive the encrypted payloads for future analysis.  When providing caching for other hashnames, the existence of and contents of all boxes must never be stored at rest and only kept in dynamic memory.
 
-Box status is advertised in any link channel by using a `"box":[boxes,capacity]` where the first number is how many boxes have waiting messages for the recipient, and the second is how many messages the sender is willing to store for the recipient.
+## Box IDs
 
-The channel is started with:
+A `box` always has a consistent unique ID that is the [SipHash](http://en.wikipedia.org/wiki/SipHash) of the recipient hashname (32 bytes) using the first half of the sender hashname (16 bytes) as the key.  The resulting 64-bit hash output is always hex encoded as a string when used in JSON: `"box":"851042800434dd49"` 
+
+## Advertising Capacity/Status
+
+Box status is advertised during any [handshake](../e3x/handshake.md) as a message using a "box" type:
+
+```
+{
+  "type": "box",
+  "quota": [used, capacity]
+}
+BODY: id1, id2, id3
+```
+
+The BODY is the list of binary 64-bit box IDs with messages waiting, only the first 120 IDs are included, any additional are truncated and must be retrieved dynamiclly by the recipient.
+
+The quota is an array of two unsigned integers where the first number is how many total waiting messages there are for the recipient, and the second is how many messages the sender is willing to cache for the recipient.
+
+No additional data is returned (such as size of each box, timestamps, or sorting) in order to minimize the metadata the sender is required to maintain.
+
+## Channel Flow
+
+The box channel is always reliable and client-server oriented (not bi-directional, one could be open in both directions) where the initial open request is sent by the client and the recipient is the server managing the box.
+
+When a box channel is opened by a sender to a recipient it uses the format:
 
 ```json
 {
   "c":1,
-  "seq":0,
+  "seq":1,
   "type":"box",
-  "box":"851042800434dd49c45299c6c3fc69ab427ec49862739b6449e1fcd77b27d3a6",
-  "csid":"1a"
+  "to":"uvabrvfqacyvgcu8kbrrmk9apjbvgvn2wjechqr3vf9c1zm3hv7g"
 }
-BODY: client's 1a public key
 ```
 
-If the "csid" key is not included it is a request for the server to send the given box hashname's parts and key in the response.
+The server calculates the box ID based on the recipient and sender, and must never return an `err` based on any internal status of the given box or recipient so as to not reveal any metadata or relationship.  If there is not capacity for the recipient the server must just accept and acknowledge all messages but not cache them.
 
-The server responds with a `"cap":10` number for the available capacity of the box to store new messages.  If no "box" is given on the request, the server picks the oldest box with messages waiting and sends a "box" in the response along with a `"parts":{...}` and the attached csid key so that the recipient can process the messages if they haven't seen that hashname yet.
+Packets may contain an optional `"x":3600` specifying the number of seconds to cache a message, the server is not required to support or enforce this, it is just a signal to help optimize cache management.
 
-Any packet on the channel can contain a message attached as the BODY in either direction, and each message must never be larger than 1024 bytes.  All messages are uniquely identified by a 32-byte value that is either specified as an optional `"key":"hex"` or defaults to the SHA-256 of the message (but may be different if provided).  If the box is at capacity, older messages are automaticlly removed when new ones are sent.
+A recipient opens a box channel to receive any waiting messages with the format:
 
-Packets from the server are messages waiting for the client hashname and will remain stored until they are removed.  Packets from the client containing messages should be stored in the given box, and may contain an optional `"expire":3600` specifying the number of seconds to store the message.  Servers should store messages until they reach a configured capacity, at which point they should remove the oldest.
+```json
+{
+  "c":1,
+  "seq":1,
+  "type":"box",
+  "box":"851042800434dd49"
+}
+```
 
-A packet with a `"key":"hex"` only and no BODY is a request to clear/remove any matching message in the box.
+If the `"box"` is not included it is a request for the next available box with any ID, and the selected box key/value is sent in a single response packet.  Any given ID must be validated as being to the recipient.
 
-Any packet from the client may contain a `"clear":true` which empties all of the messages in the box before processing any attached message.
+Upon opening, all waiting messages for the client are streamed back (flow is managed normally as a reliable channel).  If there are no messages or the box is unknown the channel is always closed by the server without an error.
+
+Any packet on the channel can contain a message attached as the BODY in either direction, and each message must never be larger than 1024 bytes.  All messages are uniquely identified/cached by the SipHash of the BODY using the box ID as the key so that the server can easily dedup messages. If the box is at capacity, older messages are automaticlly removed when new ones are sent. The server should always retain at least one message for any sender regardless of age up to the total capacity of messages (quota of 100 would be at most 1 message per 100 senders).
+
+A packet with a `"id":"16-hex"` only and no BODY from either the sender or recipient is a request to clear/remove any matching message in the box.
+
+Any packet from the client may contain a `"clear":true` which empties all of the messages in the box before processing any attached BODY.

--- a/v3/e3x/handshake.md
+++ b/v3/e3x/handshake.md
@@ -32,9 +32,6 @@ A [URI](../uri.md) was used to generate this handshake and it is included as the
 
 A [bitcoin transaction](../guides/bitcoin.md) is attached as the `BODY` to validate this handshake.
 
-### "box"
-
-A message containing metadata about [boxes](../channels/box.md) the sender has available for the recipient.
 
 ## Sequencing with `at`
 

--- a/v3/e3x/handshake.md
+++ b/v3/e3x/handshake.md
@@ -32,6 +32,9 @@ A [URI](../uri.md) was used to generate this handshake and it is included as the
 
 A [bitcoin transaction](../guides/bitcoin.md) is attached as the `BODY` to validate this handshake.
 
+### "box"
+
+A message containing metadata about [boxes](../channels/box.md) the sender has available for the recipient.
 
 ## Sequencing with `at`
 

--- a/v3/e3x/messages.md
+++ b/v3/e3x/messages.md
@@ -1,14 +1,14 @@
 # Messages - Asynchronous / Offline Content Transport with Forward Secrecy
 
-Message packets are for when one endpoint is unable to establish a channel to another and has a mechanism to send content for the other endpoint to receive independently such that both don't need to be online at the same time.
+Message packets are for encrypting small amounts of content to other entities without requiring a synchronous exchange, such that the recipient can process them at any point in the future.  They are used primarily for creating handshakes to establish synchronous [channel](channels.md) encryption that has forward secrecy guarantees, as messages alone provide a lower level of privacy and should only be used for temporary or non-secret data and never stored at rest.
 
-Messages define how to encrypt the packets but have no required internal structure (unlike channels).  There is more size overhead for encrypted message packets as they must always include the temporary public key information used, and it may be different for each one requiring additional expensive compute as well.
+Messages define how to encrypt the packets but have no required internal structure (unlike channels).  There is a larger overhead for encrypted message packets as they must always include the ephemeral public key information used and often require additional computation as well.
 
-An exchange may be used to generate one or more messages as needed and can be created as needed to process incoming ones, but messages are asynchronous and do not need the same exchanges on either side to be handled.
+An exchange may be created on demand just to generate/process one or more messages and not used for channels, but since messages are asynchronous they do not require the exchanges to be in sync to operate.
 
 All [handshakes](handshake.md) are message packets.
 
-The size of an encrypted message is determined by the application and context in which it is used, handshakes are usually small (<1400 bytes to maximize transport compatibility) and any messages intended to be sent over a transport with a low MTU may need to use [chunked encoding](../lob/chunking.md) or the app may need to do chunking of the data before encrypting.  Most apps use [channels](channels.md) for arbitrary sized/streaming data which handles this automatically.
+The size of an encrypted message is determined by the application and context in which it is used, handshakes are usually small (<1400 bytes to maximize transport compatibility) and any messages intended to be sent over a transport with a low MTU may need to use [chunked encoding](../lob/chunking.md) as the BODY of multiple messages.
 
 ## Packet Encryption
 


### PR DESCRIPTION
This is an updated/overhauled box channel definition for v3, providing the foundation to do offline and store-and-forward async patterns.