### PR TITLE
Improve consistency between hashname and cipherset documentation

### DIFF
--- a/v3/e3x/cs/README.md
+++ b/v3/e3x/cs/README.md
@@ -3,7 +3,7 @@ Cipher Sets
 
 A Cipher Set (`CS`) is a group of crypto algrithms that are used to implement the core security functions as required by e3x.  Multiple sets exist to allow an evolution of supporting newer techniques as well as adapting to different system and deployment requirements.
 
-Each set is identified with a unique identifier (`CSID`) that represents the overall selection priority. The `CSID` is a single byte, represented in lower case hex. The CSIDs are always sorted from lowest to highest preference.
+Each set is identified with a unique identifier (`CSID`) that represents the overall selection priority. The `CSID` is a single byte, represented in lower case hex. The `CSIDs` are always sorted from lowest to highest preference.
 
 | CSID          | Status | Crypto                        | Uses                  |
 |---------------|--------|-------------------------------|-----------------------|
@@ -20,14 +20,14 @@ Any `CSID` of "0*" ("01" through "0a") are reserved for special use custom Ciphe
 
 ## Exchanging CS Keys
 
-Cipher Sets are designed to be combined together for use as [hashnames](../../hashname/) so that one local instance can simultaneously use multiple CS, always selecting the best one to use based on what is available to another instance.
+Cipher Sets are designed to be combined together for use as [hashnames](../../hashname/) so that one local instance can simultaneously use multiple `CS`, always selecting the best one to use based on what is available to another instance.
 
 <a name="json" />
 ### JSON
 
-When sharing CS keys in JSON always use [base32](http://tools.ietf.org/html/rfc4648#section-3.2) encoding (lower-case, no padding) of the binary public key value to create strings that are safe to use everywhere.
+When sharing `CS` keys in JSON always use [base32](http://tools.ietf.org/html/rfc4648#section-3.2) encoding (lower-case, no padding) of the binary public key value to create strings that are safe to use everywhere.
 
-One or more Cipher Set Keys are represented in a JSON object using the `CSID` hex string as the key with a base32 string value.
+One or more Cipher Set Keys are represented in a JSON object using the `CSID` hex string as the key with a base32 string `VALUE`.
 
 ```json
 {
@@ -39,9 +39,9 @@ One or more Cipher Set Keys are represented in a JSON object using the `CSID` he
 <a name="packet" />
 ### Packet (binary key)
 
-Frequently the source for a hashname is being sent in a context where there is a specific `CSID` already known or agreed upon and only that single CS public key needs to be exchanged.  This can be consistently (and often more efficiently) encoded as a single [packet](../../lob/).
+Frequently the source for a hashname is being sent in a context where there is a specific `CSID` already known or agreed upon and only that single `CS` public key needs to be exchanged.  This can be consistently (and often more efficiently) encoded as a single [packet](../../lob/).
 
-The packet's JSON header that only includes the 32-byte `intermediate hash` values of the other CSIDs as base32 encoded strings, and the public key binary bytes of the active CSID in the BODY of the packet:
+The packet's JSON header that only includes the 32-byte `intermediate hash` values of the other `CSIDs` as base32 encoded strings, and the public key binary bytes of the active `CSID` in the `BODY` of the packet:
 
 ```
 HEAD:
@@ -53,12 +53,11 @@ HEAD:
 BODY: [2a's public key binary bytes]
 ```
 
-When the context of which CSID is already known, that CSID's `true` value in the JSON is not required to identify which key is in the BODY.
+When the context of which `CSID` is already known, that `CSID`'s `true` value in the JSON is not required to identify which key is in the `BODY`.
 
 <a name="string" />
 ### String
 
-At times it is necessary to encode all of the CS key bytes to be transferred Out-Of-Band in a simplified string context with minimal special characters.  To maximize compatibility between different implementations, whenever possible a string encoding should mimic the JSON format, including pairs of 2-character CSIDs with their base32 encoded key bytes.  When minimizing the use of special characters, the hex CSID may directly prefix the base32 string as it is always a fixed length of 2, and the delimeter character can be any non-alphanumeric that is available in the given context, such as `.`, `-`, `,`, etc.
+At times it is necessary to encode all of the `CS` key bytes to be transferred Out-Of-Band in a simplified string context with minimal special characters.  To maximize compatibility between different implementations, whenever possible a string encoding should mimic the JSON format, including pairs of 2-character `CSIDs` with their base32 encoded key bytes.  When minimizing the use of special characters, the hex `CSID` may directly prefix the base32 string as it is always a fixed length of 2, and the delimeter character can be any non-alphanumeric that is available in the given context, such as `.`, `-`, `,`, etc.
 
 See [URI](../../uri.md) for an example of this style of mapping to a query string: `link://192.168.0.55:42424/?1a=ammitozqsp4bdlvfjedusc24nlo2ndqbm4&3a=nst5jzocozz47kstrtgp6fxxifygobg5fdrb2niu2i5fytpxrj5q`
-

--- a/v3/hashname/README.md
+++ b/v3/hashname/README.md
@@ -18,17 +18,17 @@ A hashname is calculated by combining the binary public key material of one or m
 
 The generation has three distinct steps:
 
-1. Each active key is mapped to a unique one-byte `ID` based on its algorithm to provide consistent ordering
-2. The binary key material for each `ID` is hashed into intermediate digest values
+1. Each active key is mapped to a unique one-byte `CSID` based on its algorithm to provide consistent ordering
+2. The binary key material for each `CSID` is hashed into intermediate digest values
 3. An ordered roll-up hashing of the intermediate values generates the final 32-byte digest
 
-### Key IDs
+### Key CSIDs
 
-Each public key included must have a unique single-byte `ID` with a byte array `VALUE` that is the consistent binary encoding of that public key material for a given algorithm. Only one key can be used per-algorithm to calculate a hashname.
+Each public key included must have a unique single-byte `CSID` with a byte array `VALUE` that is the consistent binary encoding of that public key material for a given algorithm. Only one key can be used per-algorithm to calculate a hashname.
 
-The current public key `ID` mappings and `VALUE` binary encodings are defined in [Cipher Sets](../e3x/cs/).
+The current public key `CSID` mappings and `VALUE` binary encodings are defined in [Cipher Sets](../e3x/cs/).
 
-Any hashname generation software does not need to know or understand the Cipher Sets or support the algorithms defined there, it only has to do the consistent hashing of any given set of `ID` and `VALUE` pair inputs.
+Any hashname generation software does not need to know or understand the Cipher Sets or support the algorithms defined there, it only has to do the consistent hashing of any given set of `CSID` and `VALUE` pair inputs.
 
 ### Intermediate Hashing
 
@@ -36,7 +36,7 @@ The binary byte array `VALUE` of each public key must first be hashed, resulting
 
 ### Final Rollup
 
-To calculate the hashname the intermediate digests are sequentially hashed in ascending order by their `ID`. Each one contributes two values: the single byte `ID` value and the 32 byte intermediate digest value. The calculated hash is rolled up, wherein each resulting 32 byte binary output is concatenated with the next binary value as the input. An example calculation would look like (in pseudo-code):
+To calculate the hashname the intermediate digests are sequentially hashed in ascending order by their `CSID`. Each one contributes two values: the single byte `CSID` value and the 32 byte intermediate digest value. The calculated hash is rolled up, wherein each resulting 32 byte binary output is concatenated with the next binary value as the input. An example calculation would look like (in pseudo-code):
 
 ```js
 hash = sha256(0x1a)
@@ -71,5 +71,3 @@ When exchanging hashnames over existing IPv4/IPv6 based systems, the 4 or 16 byt
 When the IP space must be scoped into a reserved range and the port number is also available to use, the first 2 bytes may be sent as the port and then those 2 bytes in the address are hard-coded to a reserved IP prefix.
 
 A hashname may also be used as a normal MAC address with the prefix of `42` (has the locally-assigned bit set) and the first 5 bytes of the hashname: `42:XX:XX:XX:XX:XX`.
-
-


### PR DESCRIPTION
- Cypher set ID now called CSID in both places
- VALUE variable used in hashname now also mentioned in cypther set documentation
- Some minor markdown cleaning

I hope I did understand the relation between the variables correctly.