### PR TITLE
clarify that session key is not generated from identity key

### DIFF
--- a/v3/e3x/cs/1a.md
+++ b/v3/e3x/cs/1a.md
@@ -24,7 +24,7 @@ The BODY of any message packet is binary and defined with the following byte sec
 * `INNER` - the AES-128-CTR encrypted inner packet ciphertext
 * `HMAC` - 4 bytes, the calculated HMAC of all of the previous KEY+IV+INNER bytes
 
-By performing ECDH with the received ephemeral key and the recipient's identity key, the resulting 20 byte secret is SHA-256 hashed and folded once to create the 16 byte AES-128 key along with the given IV (right-zero-padded to 16 bytes).
+After performing ECDHE with the sent and received ephemeral keys from the handshakes, the resulting 20 byte secret is SHA-256 hashed and folded once to create the 16 byte AES-128 key along with the given IV (right-zero-padded to 16 bytes).
 
 Another ECDH is performed with the sender and recipients identity key, and that 20 byte secret is combined with the given IV and input to HMAC-SHA256 of the entire BODY bytes (KEY+IV+INNER) minus the HMAC, then folded three times to get the 4 byte verification value that must match/be the last 4 bytes in the BODY.
 


### PR DESCRIPTION
Assuming I understand the intent correctly, we could also just delete this line since it's duplicative of the channel setup section. via #180 