### PR TITLE
Update implementers.md

### DIFF
--- a/v3/guides/implementers.md
+++ b/v3/guides/implementers.md
@@ -210,7 +210,7 @@ When a new unknown hashname is discovered at any point (from transports or a con
 
 ### `link = mesh.link(to)`
 
-Establish a link to the given hashname.  The `to` may be a [URI](uri.md), [JSON link](link.md#json), or just a plain hashname.
+Establish a link to the given hashname.  The `to` may be a [URI](../uri.md), [JSON link](../link.md#json), or just a plain hashname.
 
 ### `link.onLink = function (state) {...}`
 
@@ -218,7 +218,7 @@ When the link state changes to up or down the app must be able to receive these 
 
 ### `link.router(bool)`
 
-Set this link to be a default (trusted) [router](routing.md), which will automatically ask it to assist in connections to any other link and provide assistance in connecting to the local endpoint.
+Set this link to be a default (trusted) [router](../routing.md), which will automatically ask it to assist in connections to any other link and provide assistance in connecting to the local endpoint.
 
 ### `mesh.discover(bool)`
 


### PR DESCRIPTION
line 213: uri.md, link.md, and line 221: routing.md 
references should be to one level up from current directory (v3/guides).